### PR TITLE
Use V2 mappings to prevent AW issues in dev

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ repositories {
 
 dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings "net.fabricmc:yarn:${project.minecraft_version}+build.${project.yarn_mappings}"
+	mappings "net.fabricmc:yarn:${project.minecraft_version}+build.${project.yarn_mappings}:v2"
 
 	modCompile "net.fabricmc:fabric-loader:${project.loader_version}"	
 	modCompile "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"


### PR DESCRIPTION
This fixes this issue you've had with fabric api here:
https://github.com/FabricMC/fabric/issues/606

Tested to make sure this is works fine in dev.

I'd also highly recommend cherry-picking this commit over to the 1.15 branch.