### PR TITLE
More bugfixes for multiworld support

### DIFF
--- a/src/main/java/ru/bulldog/justmap/util/RuleUtil.java
+++ b/src/main/java/ru/bulldog/justmap/util/RuleUtil.java
@@ -19,7 +19,7 @@ public class RuleUtil {
 	}
 	
 	public static boolean detectMultiworlds() {
-		return DataUtil.isOnline() && ClientParams.detectMultiworlds;
+		return ClientParams.detectMultiworlds;
 	}
 
 	public static boolean needRenderCaves(World world, BlockPos pos) {


### PR DESCRIPTION
* Don't wipe contents of worlds.json on game quit
* Fix json error handling when loading worlds.json
  * these two were entirely my fault, sorry
* Create new config.json with defaults if one did not exist previously
* Allow multiworld mode in singleplayer if set in config
  * It may be useful to allow naming worlds in singleplayer
* Save worlds.json after setting the name of a world