### PR TITLE
Calculate Layer.hashCode without allocation (same value as before)

### DIFF
--- a/src/main/java/ru/bulldog/justmap/map/data/Layer.java
+++ b/src/main/java/ru/bulldog/justmap/map/data/Layer.java
@@ -6,30 +6,30 @@ public class Layer {
 	public final static Layer SURFACE = new Layer("surface", 256);
 	public final static Layer CAVES = new Layer("caves", 8);
 	public final static Layer NETHER = new Layer("nether", 16);
-	
+
 	public final String name;
 	public final int height;
-	
+
 	private Layer(String name, int height) {
 		this.name = name;
 		this.height = height;
 	}
-	
+
 	@Override
 	public int hashCode() {
-		return Arrays.hashCode(new int[] { name.hashCode(), height });
+		return 31 * name.hashCode() + height;
 	}
-	
+
 	@Override
 	public boolean equals(Object obj) {
 		if (this == obj) return true;
 		if (!(obj instanceof Layer)) return false;
-		
+
 		Layer layer = (Layer) obj;
 		return this.name == layer.name &&
 			   this.height == layer.height;
 	}
-	
+
 	@Override
 	public String toString() {
 		return this.name.toUpperCase();


### PR DESCRIPTION
`Layer.hashCode` is creating a new array just to call `hashCode` on it. This patch inlines the actual logic from `Arrays.hashCode` but avoids the gratuitous array creation.

I have my IDE configured to remove trailing whitespaces. Let me know if these unrelated whitespace changes are unacceptable and I'll revert them.