### PR TITLE
Update ModMenu to use new API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,10 @@ minecraft {}
 
 repositories {
 	maven { url "https://maven.fabricmc.net/" }
+	maven {
+		name 'Terraformers'
+		url 'https://maven.terraformersmc.com/releases/'
+	}
 	jcenter()
 	flatDir {
 		dirs 'libs'
@@ -52,7 +56,7 @@ dependencies {
 
 	modCompile "net.fabricmc:fabric-loader:${project.loader_version}"	
 	modCompile "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-	modCompile "io.github.prospector:modmenu:${project.modmenu_version}"
+	modCompile "com.terraformersmc:modmenu:${project.modmenu_version}"
 	modCompile "me.shedaniel.cloth:config-2:${project.cloth_version}"
 	
 	include "me.shedaniel.cloth:config-2:${project.cloth_version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ archives_base_name = justmap
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric
 fabric_version = 0.25.1+build.416-1.16
 cloth_version = 4.8.1
-modmenu_version = 1.14.6+build.31
+modmenu_version = 1.16.17

--- a/src/main/java/ru/bulldog/justmap/client/config/ModMenuEntry.java
+++ b/src/main/java/ru/bulldog/justmap/client/config/ModMenuEntry.java
@@ -1,7 +1,7 @@
 package ru.bulldog.justmap.client.config;
 
-import io.github.prospector.modmenu.api.ConfigScreenFactory;
-import io.github.prospector.modmenu.api.ModMenuApi;
+import com.terraformersmc.modmenu.api.ConfigScreenFactory;
+import com.terraformersmc.modmenu.api.ModMenuApi;
 
 import net.fabricmc.api.Environment;
 import net.fabricmc.api.EnvType;


### PR DESCRIPTION
Update ModMenu to use new API. io.github.prospector.modmenu.api is deprecated and will be removed in 1.18.